### PR TITLE
Improve capability handling for remote instances

### DIFF
--- a/seleniumbase/core/browser_launcher.py
+++ b/seleniumbase/core/browser_launcher.py
@@ -995,9 +995,6 @@ def get_remote_driver(
         # Set custom desired capabilities
         selenoid = False
         selenoid_options = None
-        screen_resolution = None
-        browser_version = None
-        platform_name = None
         for key in desired_caps.keys():
             capabilities[key] = desired_caps[key]
             if key == "selenoid:options":
@@ -1318,36 +1315,13 @@ def get_remote_driver(
                 keep_alive=True,
             )
     elif browser_name == constants.Browser.REMOTE:
-        selenoid = False
-        selenoid_options = None
-        screen_resolution = None
-        browser_version = None
-        platform_name = None
-        for key in desired_caps.keys():
-            if key == "selenoid:options":
-                selenoid = True
-                selenoid_options = desired_caps[key]
-            elif key == "screenResolution":
-                screen_resolution = desired_caps[key]
-            elif key == "version" or key == "browserVersion":
-                browser_version = desired_caps[key]
-            elif key == "platform" or key == "platformName":
-                platform_name = desired_caps[key]
+        selenoid = "selenoid:options" in desired_caps
         if selenium4:
             remote_options = ArgOptions()
-            remote_options.set_capability("cloud:options", desired_caps)
-            if selenoid:
-                snops = selenoid_options
-                remote_options.set_capability("selenoid:options", snops)
-            if screen_resolution:
-                scres = screen_resolution
-                remote_options.set_capability("screenResolution", scres)
-            if browser_version:
-                br_vers = browser_version
-                firefox_options.set_capability("browserVersion", br_vers)
-            if platform_name:
-                plat_name = platform_name
-                firefox_options.set_capability("platformName", plat_name)
+            # just shovel desired caps so that --browser remote takes the --cap-file literally.
+            # don't try and handle each possible key on an 'if present' basis.
+            for cap_name, cap_value in desired_caps.items():
+                remote_options.set_capability(cap_name, cap_value)
             return webdriver.Remote(
                 command_executor=address,
                 options=remote_options,


### PR DESCRIPTION
 - Removal of the `cloud:options` handling, this is an interface that should be prefixed by specific vendors
 - Bug fix firefox_options typos in remote_options
 - Shovel `desired_caps` into the `ArgOptions` instance

I need to test a lot more and study the code a lot more, I am doing this atm at a quick glance, so it's definitely not fit for merging, opening this as a means to chat about the changes/outstanding changes.

The aim is that `--browser remote` should just work as it used to.